### PR TITLE
 pass Authorization via msg.authorization

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -334,7 +334,9 @@ module.exports = function(RED) {
 
     function callGraphQLServer(query, variables = {}) {
       let headers = {}
-      if (node.graphqlConfig.authorization) {
+      if (node.msg.authorization) {
+        headers["Authorization"] = node.msg.authorization
+      } else if (node.graphqlConfig.authorization) {
         headers["Authorization"] = node.graphqlConfig.authorization
       }
       //RED.log.debug('callGraphQLServer, node: ' + safeJSONStringify(node));


### PR DESCRIPTION
Authorization header can now optionally be passed via msg.authorization field. Allows to get the authorization token from another source or a previous call instead of specifying it in the graphql connection.
In my case i have to do a graphql call with user/pass to gain the token and then pass this one in the other calls. 
 
Would be really great if you could add that to your branch and update the npm package. Thanks a lot.