### PR TITLE
'showDebug' and ability to pass in 'customHeaders'

### DIFF
--- a/graphql.html
+++ b/graphql.html
@@ -18,18 +18,18 @@
         category: 'config',
         color: "rgb(218, 196, 180)",
         defaults: {
+            name: { value: "", required: false },
             endpoint: { value: "", required: true },
             token: { value: "", required: false },
             user: { value: "", required: false },
-            password: { value: "", required: false },
-            name: { value: "", required: false }
+            password: { value: "", required: false }
         },
         credentials: {
             user: { type: "text" },
             password: { type: "password" },
             serviceTicket: { type: "password" },
             token: { type: "password" },
-            authorization: { type: "password" }
+            authorization: { type: "password" },  
         },
         align: 'left',
         label: function() {
@@ -47,6 +47,10 @@
         <label for="node-input-graphql"><i class="fa fa-bookmark"></i> <span data-i18n="graphql.label.endpoint"></span></label>
         <input type="text" id="node-input-graphql">
     </div>
+    <!-- <div class="form-row">
+        <label for="node-input-customHeaders"><i class="fa fa-bookmark"></i> <span data-i18n="graphql.label.customHeaders"></span></label>
+        <input type="json" id="node-input-customHeaders">
+    </div> -->
     <div class="form-row" style="position: relative; margin-bottom: 0px;">
         <label for="node-input-template"><i class="fa fa-file-code-o"></i> <span data-i18n="graphql.label.query"></span></label>
         <input type="hidden" id="node-input-template" autofocus="autofocus">
@@ -71,6 +75,10 @@
             <option value="plain" data-i18n="graphql.label.plain"><span data-i18n="template.label.plain"></span></option>
         </select>
     </div>
+    <div class="form-row">
+        <label for="node-input-showDebug"><i class="fa fa-bookmark"></i> <span data-i18n="graphql.label.showDebug"></span></label>
+        <input type="checkbox" id="node-input-showDebug">
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -93,7 +101,9 @@
             graphql: {type: "graphql-server", required: true },
             format: {value:"handlebars", required: false },
             syntax: {value:"mustache", required: false },
-            template: {value:"{\n getUserById(id: 32) {\n  firstName\n  lastName\n  email\n }\n}", required: true }
+            template: {value:"{\n getUserById(id: 32) {\n  firstName\n  lastName\n  email\n }\n}", required: true },
+            showDebug: {value: false, required: false}
+            // customHeaders:{value:"{}", required: false}
         },
         inputs: 1,
         outputs: 2,
@@ -119,6 +129,18 @@
                 types: ['msg','flow','global'],
                 typeField: $("#node-input-fieldType")
             });
+            if (!this.showDebug) {
+                // this.showDebug = false;
+                $("#node-input-showDebug").val(this.showDebug);
+            }
+
+            // $("#node-input-customHeaders").typedInput({
+            //     default: 'json',
+            //     typeField: $("#node-input-customHeaders"),
+            //     label: "msg.customHeaders",
+            //     type:"json",
+            //     types:["json"]
+            // })
             this.editor = RED.editor.createEditor({
                 id: 'node-input-template-editor',
                 mode: 'ace/mode/html',
@@ -142,6 +164,7 @@
         oneditsave: function() {
             $("#node-input-template").val(this.editor.getValue())
             delete this.editor;
+            $("#node-input-showDebug").val(this.showDebug.getValue())
         },
         oneditresize: function(size) {
             var rows = $("#dialog-form>div:not(.node-text-editor-row)");
@@ -159,4 +182,6 @@
 
 <script type="text/x-red" data-help-name="graphql">
     <p>This node executes a GraphQL Query or Mutation</p>
+    <p>Optionally receives msg.customHeaders to dynamically send headers as needed</p>
+    <p>Outputs msg.debugInfo if the options is checked</p>
 </script>

--- a/locales/en-US/graphql.json
+++ b/locales/en-US/graphql.json
@@ -9,7 +9,9 @@
             "mustache": "mustache",
             "plain": "plain",
             "apivers": "API Vers",
-            "authorization": "Authorization Header"
+            "authorization": "Authorization Header",
+            "showDebug": "Show Debug info"
+            
         },
         "status": {
             "calling": "calling",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-graphql",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A Node-RED node to make GraphQL calls",
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Added a 'showDebug' option that will display more of the response in msg.debugInfo. added ability to pass in msg.customHeaders. 

1. I wasnt able to see errors that were returned under the `response.data` or other errors from more more complex queries because it automatically returned `response.data.data` as the payload, so this adds a debug option to be able to turn that on.
2. I needed to pass in an 'auth' header different than 'Authorization', so this lets you pass in headers.