### PR TITLE
Fixed issue when payload is not defined for all use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A NodeRed node to execute GraphQL Queries.
 
 | Vers  | Changes       |
 | ----- | -------------------------------------------------------- |
+| 2.2.0 | Really fix payload issue |
 | 2.1.2 | Fix payload init issue |
 | 2.1.0 | Bearer Token Authentication |
 | 2.0.1 | Update dependencies (`axios` & `mustache`), fix node-red scorecard issues |

--- a/graphql.js
+++ b/graphql.js
@@ -144,6 +144,7 @@ module.exports = function(RED) {
         }
       })
         .then(function(response) {
+          if (!node.msg.payload) node.msg.payload = {};
           switch (true) {
             case response.status == 200 && !response.data.errors:
               node.status({
@@ -151,7 +152,6 @@ module.exports = function(RED) {
                 shape: "dot",
                 text: RED._("graphql.status.success")
               });
-              if (!node.msg.payload) node.msg.payload = {};
               node.msg.payload.graphql = response.data.data; // remove .data to see entire response
               if (node.showDebug){
                 node.msg.debugInfo = {
@@ -189,6 +189,7 @@ module.exports = function(RED) {
         .catch(function(error) {
           RED.log.debug("error:" + error);
           node.status({ fill: "red", shape: "dot", text: "error" });
+          if (!node.msg.payload) node.msg.payload = {};
           node.msg.payload.graphql = { error };
           node.error("error: " + error);
           node.send([null, node.msg]);

--- a/graphql.js
+++ b/graphql.js
@@ -3,7 +3,7 @@ module.exports = function(RED) {
   var axios = require("axios");
   var mustache = require("mustache");
 
-  var vers = "2.1.2";
+  var vers = "2.2.0";
 
   function isReadable(value) {
     return typeof value === 'object' && typeof value._read === 'function' && typeof value._readableState === 'object'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-graphql",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A Node-RED node to make GraphQL calls",
   "dependencies": {
     "axios": "~1.2.1",


### PR DESCRIPTION
Missing `msg.payload` is currently handled only for use cases when GraphQL server responds with a success message.
This change will handle it for all use cases.